### PR TITLE
Add highlighting for non-built-in functions

### DIFF
--- a/syntaxes/ahk.tmLanguage
+++ b/syntaxes/ahk.tmLanguage
@@ -118,6 +118,12 @@
 		</dict>
 		<dict>
 			<key>match</key>
+			<string>\b(?!MsgBox)([\w]+)(?=\()</string>
+			<key>name</key>
+			<string>support.function.ahk</string>
+		</dict>
+		<dict>
+			<key>match</key>
 			<string>^MsgBox</string>
 			<key>name</key>
 			<string>support.function.msgbox.ahk</string>


### PR DESCRIPTION
Functions that are not built-ins will now be highlighted